### PR TITLE
Fix enable and disable job scripts for pipeline jobs

### DIFF
--- a/disable-jobs.groovy
+++ b/disable-jobs.groovy
@@ -9,5 +9,5 @@ def chosenJobs = jenkins.items.findAll{job -> jobNames.contains(job.name)};
 
 chosenJobs.each { job ->
   println "Disabling job " + job.name;
-  job.disable()
+  job.doDisable()
 }

--- a/enable-jobs.groovy
+++ b/enable-jobs.groovy
@@ -9,5 +9,5 @@ def chosenJobs = jenkins.items.findAll{job -> jobNames.contains(job.name)};
 
 chosenJobs.each { job ->
   println "Enabling job " + job.name;
-  job.enable()
+  job.doEnable()
 }


### PR DESCRIPTION
The scripts were not working properly because `enable()` and `disable()` are not members of a ParameterizedJob (e.g. the pipeline jobs we use for nightly builds). Changing to `doEnable` and `doDisable` seems to work for both freestyle and pipeline jobs, tested here:
https://builds.mantidproject.org/job/tom_test_enable_jobs/6/

see here also:
https://javadoc.jenkins.io/plugin/workflow-job/org/jenkinsci/plugins/workflow/job/WorkflowJob.html