### PR TITLE
Script for setting default pipeline publishing branch

### DIFF
--- a/set-branch-to-publish.groovy
+++ b/set-branch-to-publish.groovy
@@ -1,0 +1,21 @@
+/**
+ * Set value of Global property BRANCH_TO_PUBLISH that determines which of the
+ * nightly pipelines will be published.
+ *
+ * Required variable bindings:
+ *   branchName - Name of the branch to publish, usually either main or release-next
+ */
+def jenkins = jenkins.model.Jenkins.instance;
+def nodes = jenkins.getGlobalNodeProperties()
+nodes.getAll(hudson.slaves.EnvironmentVariablesNodeProperty.class)
+
+if ( nodes.size() != 1 ) {
+  println("error: unexpected number of environment variable containers: "
+          + nodes.size()
+          + " expected: 1")
+} else {
+  def envVars = nodes.get(0).getEnvVars()
+  envVars.put("BRANCH_TO_PUBLISH", branchName)
+  jenkins.save()
+  println("BRANCH_TO_PUBLISH set to " + branchName)
+}


### PR DESCRIPTION
Added a groovy script that can set the global propertry `BRANCH_TO_PUBLISH`, which can be used in our open and close release release testing jobs to switch the publishing between release-next and main.

It was tested successfully here (see console output):
https://builds.mantidproject.org/job/test_groovy_script/6/

The value had indeed been changed:
![image](https://user-images.githubusercontent.com/8058899/217205998-10b5d148-84aa-4ac5-a371-032045da839b.png)
